### PR TITLE
experiment: replace internal divs with unregistered custom elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hsablonniere/musiq",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Web components for rendering musical instruments, chords, and scales",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/src/mq-fretboard/mq-fretboard.ts
+++ b/src/mq-fretboard/mq-fretboard.ts
@@ -74,58 +74,51 @@ export class MqFretboard extends LitElement {
     const neckSpan = `${so + 1} / ${so + this.strings * 3 + 1}`;
 
     return html`
-      <div
-        class="grid"
+      <mq-fretboard-grid
         style="grid-template-columns: ${(isV ? stringTracks : neckTracks).join(
           " ",
         )}; grid-template-rows: ${(isV ? neckTracks : stringTracks).join(" ")};"
       >
-        <div
-          class="neck"
+        <mq-fretboard-neck
           style="${this._place(`2 / ${neckEnd}`, this.fullNeck ? neckSpan : fretSpan)}"
-        ></div>
+        ></mq-fretboard-neck>
         ${showNut
-          ? html`<div class="nut" style="${this._place("2 / 3", fretSpan)}"></div>`
-          : html`<div class="fret first-fret" style="${this._place("2 / 3", fretSpan)}"></div>`}
+          ? html`<mq-fretboard-nut style="${this._place("2 / 3", fretSpan)}"></mq-fretboard-nut>`
+          : html`<mq-fretboard-fret class="first-fret" style="${this._place("2 / 3", fretSpan)}"></mq-fretboard-fret>`}
         ${Array.from({ length: fretCount }, (_, i) => {
           const p = fretWire(this.startFret + i);
-          return html`<div class="fret" style="${this._place(`${p} / ${p + 1}`, fretSpan)}"></div>`;
+          return html`<mq-fretboard-fret style="${this._place(`${p} / ${p + 1}`, fretSpan)}"></mq-fretboard-fret>`;
         })}
         ${Array.from({ length: this.strings }, (_, i) => {
           const c = sc(i + 1);
-          return html`<div
-            class="string"
+          return html`<mq-fretboard-string
             style="${this._place(`3 / ${neckEnd}`, `${c} / ${c + 1}`)}"
-          ></div>`;
+          ></mq-fretboard-string>`;
         })}
         ${markers.map((f) => {
           const space = fretSpace(f);
           const np = `${space} / ${space + 1}`;
           if (DOUBLE_MARKERS.has(f)) {
             const half = Math.ceil(this.strings / 2);
-            return html` <div
-                class="inlay"
+            return html` <mq-fretboard-inlay
                 style="${this._place(np, `${sc(1) - 1} / ${sc(half) + 2}`)}"
-              ></div>
-              <div
-                class="inlay"
+              ></mq-fretboard-inlay>
+              <mq-fretboard-inlay
                 style="${this._place(np, `${sc(half + 1) - 1} / ${sc(this.strings) + 2}`)}"
-              ></div>`;
+              ></mq-fretboard-inlay>`;
           }
-          return html`<div
-            class="inlay"
+          return html`<mq-fretboard-inlay
             style="${this._place(np, `${sc(1) - 1} / ${sc(this.strings) + 2}`)}"
-          ></div>`;
+          ></mq-fretboard-inlay>`;
         })}
         ${numFrets.map((f) => {
           const space = fretSpace(f);
-          return html`<div
-            class="fret-number"
+          return html`<mq-fretboard-fret-number
             part="fret-number"
             style="${this._place(`${space} / ${space + 1}`, fnumPos)}"
           >
             ${f}
-          </div>`;
+          </mq-fretboard-fret-number>`;
         })}
         ${Array.from({ length: this.strings }, (_, i) => {
           const s = i + 1;
@@ -167,7 +160,7 @@ export class MqFretboard extends LitElement {
               ></slot>`;
             })
           : nothing}
-      </div>
+      </mq-fretboard-grid>
     `;
   }
 
@@ -180,11 +173,11 @@ export class MqFretboard extends LitElement {
       display: inline-block;
     }
 
-    .grid {
+    mq-fretboard-grid {
       display: grid;
     }
 
-    :host([orientation="vertical"]) .grid {
+    :host([orientation="vertical"]) mq-fretboard-grid {
       display: inline-grid;
     }
 
@@ -192,32 +185,32 @@ export class MqFretboard extends LitElement {
       display: block;
     }
 
-    .neck {
+    mq-fretboard-neck {
       background: var(--mq-fretboard-neck-color);
     }
 
-    .nut {
+    mq-fretboard-nut {
       background-color: var(--mq-fretboard-nut-color, #000);
       border-radius: var(--mq-fretboard-nut-radius, 0);
     }
 
-    :host(:not([orientation="vertical"])) .nut {
+    :host(:not([orientation="vertical"])) mq-fretboard-nut {
       width: var(--mq-fretboard-nut-width, 3px);
     }
 
-    :host([orientation="vertical"]) .nut {
+    :host([orientation="vertical"]) mq-fretboard-nut {
       height: var(--mq-fretboard-nut-width, 3px);
     }
 
-    .fret {
+    mq-fretboard-fret {
       background-color: var(--mq-fretboard-fret-color, #000);
     }
 
-    :host(:not([orientation="vertical"])) .fret {
+    :host(:not([orientation="vertical"])) mq-fretboard-fret {
       width: var(--mq-fretboard-fret-width, 1px);
     }
 
-    :host([orientation="vertical"]) .fret {
+    :host([orientation="vertical"]) mq-fretboard-fret {
       height: var(--mq-fretboard-fret-width, 1px);
     }
 
@@ -231,19 +224,19 @@ export class MqFretboard extends LitElement {
       margin-top: calc(var(--mq-fretboard-nut-width, 3px) - var(--mq-fretboard-fret-width, 1px));
     }
 
-    .string {
+    mq-fretboard-string {
       background-color: var(--mq-fretboard-string-color, #000);
     }
 
-    :host(:not([orientation="vertical"])) .string {
+    :host(:not([orientation="vertical"])) mq-fretboard-string {
       height: var(--mq-fretboard-string-width, 1px);
     }
 
-    :host([orientation="vertical"]) .string {
+    :host([orientation="vertical"]) mq-fretboard-string {
       width: var(--mq-fretboard-string-width, 1px);
     }
 
-    .inlay {
+    mq-fretboard-inlay {
       background-color: var(--mq-fretboard-inlay-color, #000);
       width: var(--mq-fretboard-inlay-size, 6px);
       height: var(--mq-fretboard-inlay-size, 6px);
@@ -251,22 +244,22 @@ export class MqFretboard extends LitElement {
       place-self: center;
     }
 
-    .fret-number {
+    mq-fretboard-fret-number {
       color: inherit;
       font-size: 0.75em;
       line-height: 1;
       place-self: center;
     }
 
-    :host(:not([orientation="vertical"])) .fret-number {
+    :host(:not([orientation="vertical"])) mq-fretboard-fret-number {
       margin-top: 0.3em;
     }
 
-    :host([orientation="vertical"]) .fret-number {
+    :host([orientation="vertical"]) mq-fretboard-fret-number {
       margin-right: 0.3em;
     }
 
-    :host([left-handed]) .grid {
+    :host([left-handed]) mq-fretboard-grid {
       transform: scaleX(-1);
     }
 

--- a/src/mq-fretboard/mq-fretboard.ts
+++ b/src/mq-fretboard/mq-fretboard.ts
@@ -277,7 +277,7 @@ export class MqFretboard extends LitElement {
     }
 
     :host([left-handed]) slot,
-    :host([left-handed]) .fret-number {
+    :host([left-handed]) mq-fretboard-fret-number {
       transform: scaleX(-1);
     }
   `;

--- a/src/mq-piano/mq-piano.ts
+++ b/src/mq-piano/mq-piano.ts
@@ -135,7 +135,7 @@ export class MqPiano extends LitElement {
     const startNote = NOTES_BY_SEMITONE[this._startSemitone % 12];
     if (startNote.type === "white" && this._startSemitone > 0 && isBlack(this._startSemitone - 1)) {
       const w = this.mode === "centered" ? startNote.centered : startNote.accurate;
-      blackLayer.push(html`<div style="flex:${w.startPad}"></div>`);
+      blackLayer.push(html`<mq-piano-pad style="flex:${w.startPad}"></mq-piano-pad>`);
     }
 
     for (let semitone = this._startSemitone; semitone <= this._endSemitone; semitone++) {
@@ -150,11 +150,10 @@ export class MqPiano extends LitElement {
 
         const w = this.mode === "centered" ? note.centered : note.accurate;
         whiteLayer.push(this._renderKey(note, octave, w));
-        blackLayer.push(html` <div
-          class="white-spacer"
-          data-key="${note.names.join("-")}"
+        blackLayer.push(html` <mq-piano-white-spacer
+          key="${note.names.join("-")}"
           style="--top-width:${w.top}"
-        ></div>`);
+        ></mq-piano-white-spacer>`);
         prevWasWhite = true;
       } else {
         whiteLayer.push(this._borderTpl);
@@ -166,26 +165,26 @@ export class MqPiano extends LitElement {
     const endNote = NOTES_BY_SEMITONE[this._endSemitone % 12];
     if (endNote.type === "white" && isBlack(this._endSemitone + 1)) {
       const w = this.mode === "centered" ? endNote.centered : endNote.accurate;
-      blackLayer.push(html`<div style="flex:${w.endPad}"></div>`);
+      blackLayer.push(html`<mq-piano-pad style="flex:${w.endPad}"></mq-piano-pad>`);
     }
 
     return html`
-      <div class="layer layer-white">${whiteLayer}</div>
-      <div class="layer layer-black">${blackLayer}</div>
+      <mq-piano-layer type="white">${whiteLayer}</mq-piano-layer>
+      <mq-piano-layer type="black">${blackLayer}</mq-piano-layer>
     `;
   }
 
   private _renderKey(note: Note, octave: number, w?: { top: number; bottom: number }) {
     const style = w == null ? "" : `--top-width:${w.top};--bottom-width:${w.bottom}`;
     return html`
-      <div
+      <mq-piano-key
         part="key key-${note.type}"
-        data-type="${note.type}"
-        data-key="${note.names.join("-")}"
+        type="${note.type}"
+        key="${note.names.join("-")}"
         style="${style}"
       >
         ${note.names.map((alias) => html` <slot name="note-${alias}${octave}"></slot>`)}
-      </div>
+      </mq-piano-key>
     `;
   }
 
@@ -203,29 +202,29 @@ export class MqPiano extends LitElement {
       grid-template-rows: 2fr 1fr;
     }
 
-    .layer {
+    mq-piano-layer {
       display: flex;
       grid-column: 1 / 2;
     }
 
-    .layer-white {
+    mq-piano-layer[type="white"] {
       grid-row: 1 / 3;
     }
 
-    .layer-black {
+    mq-piano-layer[type="black"] {
       grid-row: 1 / 2;
     }
 
-    [data-type="white"] {
+    mq-piano-key[type="white"] {
       background-color: #fff;
       flex: var(--bottom-width);
     }
 
-    .white-spacer {
+    mq-piano-white-spacer {
       flex: var(--top-width);
     }
 
-    [data-type="black"] {
+    mq-piano-key[type="black"] {
       background-color: #000;
       flex: 14;
     }
@@ -235,7 +234,7 @@ export class MqPiano extends LitElement {
       background-color: var(--mq-piano-border-color-inner, var(--border-color));
     }
 
-    .layer-black .border {
+    mq-piano-layer[type="black"] .border {
       visibility: hidden;
     }
   `;


### PR DESCRIPTION
## Summary

Exploration of using unregistered custom elements (`mq-piano-key`, `mq-fretboard-neck`, etc.) instead of `<div>` for internal shadow DOM elements in `mq-piano` and `mq-fretboard`.

The idea: a tag with a dash triggers custom element parsing but works fine without `customElements.define()` — the browser treats it as a plain `HTMLElement`.

## Pros

- **DOM inspector readability** — `<mq-piano-key type="white">` vs `<div data-type="white">`
- **Template readability** — self-describing tag names
- **Cleaner CSS selectors** — `mq-piano-key[type="white"]` vs `[data-type="white"]`
- **Shorter attributes** — `key="C"` vs `data-key="C"`

## Cons

- **Contributor ambiguity** — no way to tell if the element is registered somewhere. A `<div>` is always a `div`, no doubt.
- **Indistinguishable from an error** — typo in the tag name? Deleted element? Dead code? No signal.
- **Undefined attributes** — `type`, `key` exist in no interface/class. No validation, no autocomplete, no documentation.
- **Shadow DOM leak** — a consumer of `<mq-piano>` can call `customElements.define('mq-piano-key', ...)` and inject behavior/style into internal elements. Impossible with `<div>`.
- **Linting noise** — lit-analyzer, eslint-plugin-lit, IDE plugins will flag unregistered custom elements as unknown → extra config to suppress.
- **No TypeScript benefit** — `querySelector('mq-piano-key')` returns generic `HTMLElement`. No type help on custom attributes.
- **Spec-valid but semantically misleading** — the Custom Elements spec explicitly supports undefined elements (they remain `HTMLElement` until upgraded, *"similar to a span"*). The upgrade mechanism is intentional. However, using this syntax without *ever* intending to register creates a false signal — readers and tools expect a definition to exist or arrive later.
- **Unexpected upgrade risk** — a third-party dependency or consumer could accidentally register one of these names → silent upgrade of all elements, unpredictable behavior.
- **`instanceof` useless** — all elements are `HTMLElement`, no discriminating subclass.
- **DevTools noise** — browser DevTools flag undefined custom elements (greyed-out "custom" badge in Chrome), perceived as a warning.

## Conclusion

The readability gains are real but marginal. The downsides — shadow DOM encapsulation leak, tooling friction, upgrade risk, contributor confusion — outweigh them. Sticking with `<div>` + classes/data attributes.